### PR TITLE
[FIX] 알림 API 및 신고 API 로직 개편

### DIFF
--- a/src/controller/friendController.ts
+++ b/src/controller/friendController.ts
@@ -233,12 +233,6 @@ const postReport = async (req: Request, res: Response) => {
         .send(fail(sc.BAD_REQUEST, rm.FAIL_REPORT_POST));
     }
 
-    if (data == sc.NOT_FOUND) {
-      return res
-        .status(sc.NOT_FOUND)
-        .send(fail(sc.NOT_FOUND, rm.REPORT_NO_USER));
-    }
-
     postMail(friendReportRequestDto, +friendId, +userId);
 
     return res.status(sc.OK).send(success(sc.OK, rm.SUCCESS_REPORT_POST));

--- a/src/service/alarmService.ts
+++ b/src/service/alarmService.ts
@@ -24,7 +24,7 @@ const getAlarm = async (auth: number) => {
 
   const promises = alarmData.map(async (data) => {
     //? 팔로우 한 경우
-    if (data.typeId === 1) {
+    if (data.typeId === 1 || data.typeId === 4) {
       const userData = await prisma.user.findFirst({
         where: {
           id: data.senderId,

--- a/src/service/bookshelfService.ts
+++ b/src/service/bookshelfService.ts
@@ -126,7 +126,7 @@ const deleteMyBook = async (bookshelfId: number) => {
     });
   }
 
-  //* 책삭제 했을때 알림들 다 삭제됨
+  //* 책 삭제 했을때 알림들 다 삭제됨
   const deleteData = await prisma.newBookAlarm.findMany({
     where: {
       bookshelfId: bookshelfId,

--- a/src/service/friendService.ts
+++ b/src/service/friendService.ts
@@ -190,6 +190,7 @@ const searchUser = async (nickname: string, auth: number) => {
 
 //* [POST] 팔로우 하기
 const followFriend = async (friendId: number, auth: number) => {
+  // 내가 이전에 팔로우를 이미 했는지 확인
   const followData = await prisma.friend.findFirst({
     where: {
       receiverId: friendId,
@@ -212,14 +213,45 @@ const followFriend = async (friendId: number, auth: number) => {
     },
   });
 
-  // 알림 테이블에도 추가
-  await prisma.alarm.create({
-    data: {
-      senderId: auth,
-      receiverId: friendId,
-      typeId: 1,
+  // 상대가 나를 팔로우 하는지 확인
+  const followBackData = await prisma.friend.findFirst({
+    where: {
+      receiverId: auth,
+      senderId: friendId,
+    },
+    select: {
+      followId: true,
     },
   });
+
+  if (followBackData != null) {
+    await prisma.alarm.create({
+      data: {
+        senderId: auth,
+        receiverId: friendId,
+        typeId: 1,
+      },
+    });
+
+    // 상대 알림에서도 맞팔로 바꾸기
+    await prisma.alarm.updateMany({
+      where: {
+        senderId: friendId,
+        receiverId: auth,
+      },
+      data: {
+        typeId: 1,
+      },
+    });
+  } else {
+    await prisma.alarm.create({
+      data: {
+        senderId: auth,
+        receiverId: friendId,
+        typeId: 4,
+      },
+    });
+  }
 
   // 푸시 알림 보내기
   const receiverUser = await prisma.user.findFirst({
@@ -227,6 +259,7 @@ const followFriend = async (friendId: number, auth: number) => {
       id: friendId,
     },
   });
+
   const senderUser = await prisma.user.findFirst({
     where: {
       id: auth,

--- a/src/service/friendService.ts
+++ b/src/service/friendService.ts
@@ -371,16 +371,6 @@ const postReport = async (
   friendId: number,
   friendReportRequestDto: FriendReportRequestDTO
 ) => {
-  const friendData = await prisma.friend.findFirst({
-    where: {
-      senderId: userId,
-      receiverId: friendId,
-    },
-  });
-
-  if (!friendData) {
-    return sc.NOT_FOUND;
-  }
   // 특정 이유 적은 경우
   if (!friendReportRequestDto.etc) {
     const reportResult = await prisma.report.create({


### PR DESCRIPTION
### ⭐ Related Issue
* closed #256 

### 📌 Work description
* 알림 API를 개편하였습니다.

    * 알림 리스트 뷰에서 선팔로우, 맞팔로우에 따라서 라우팅 되는 뷰가 달라지기 때문에 알림 타입을 두개로 나눠서 로직을 수정하였습니다.
    * 맞팔로우의 경우 alarmType을 1로, 선팔로우의 경우 alarmType을 4로 나눴습니다.

* 신고 API를 개편하였습니다.

    - 기존에는 친구인 경우에만 상대방을 신고할 수 있었지만, 친구가 아니어도 신고가 가능해야 된다는 기획측의 요청 사항에 따라 검증하는 로직을 제거하였습니다.


### ✔️ Questioon & PR point
* 
