### PR TITLE
#263 [FIX] 팔로우 시, 이전에 내가 팔로우 했었던 알림을 삭제하고 최신 팔로우 알림만 생성되게 수정

### DIFF
--- a/src/service/friendService.ts
+++ b/src/service/friendService.ts
@@ -213,6 +213,14 @@ const followFriend = async (friendId: number, auth: number) => {
     },
   });
 
+  // 상대한테 이전에 보냈던 알림 삭제
+  await prisma.alarm.deleteMany({
+    where: {
+      receiverId: friendId,
+      senderId: auth,
+    },
+  });
+
   // 상대가 나를 팔로우 하는지 확인
   const followBackData = await prisma.friend.findFirst({
     where: {


### PR DESCRIPTION
### ⭐ Related Issue
* closed #263 

### 📌 Work description
* 기획 측 요청에 따라 팔로우 시, 이전에 내가 팔로우 했었던 알림을 삭제하고 최신 팔로우 알림만 생성되게 수정하였습니다.

### ✔️ Questioon & PR point
* 
